### PR TITLE
Migrate from deprecated xvfb action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           postgresql db: grape_on_rails_test
           postgresql user: test
           postgresql password: password
-      - uses: GabrielBB/xvfb-action@v1
+      - uses: coactions/setup-xvfb@v1
         with:
           run: |
             bundle exec rake db:create


### PR DESCRIPTION
Old action is deprecated and will not be updated. Migrate to suggested replacement that uses Node 16. Drop in replacement.