### PR TITLE
Fix running steps on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [Grape](http://github.com/ruby-grape/grape) API mounted on Rails.
 
 ```
 bin/setup
+rails s
 ```
 
 - Try http://localhost:3000/api/ping or http://localhost:3000/api/protected/ping with _username_ and _password_.


### PR DESCRIPTION
Related PR: #49

## What the problem is
- The bin/setup command doesn't run the rails server. So we should re-add the rails s command.

## What I did
- Re-add `rails s` command in the Run steps

## What I checked
- Run `#Run` steps.

<details>
<summary> Log </summary>

```console
% bin/setup
== Installing dependencies ==
The Gemfile's dependencies are satisfied

== Preparing database ==

== Removing old logs and tempfiles ==

== Restarting application server ==
% rails s
=> Booting Puma
=> Rails 7.0.4.3 application starting in development 
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 5.6.4 (ruby 3.1.2-p20) ("Birdie's Version")
*  Min threads: 5
*  Max threads: 5
*  Environment: development
*          PID: 53753
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
Use Ctrl-C to stop
```

</details>